### PR TITLE
Add MCU Extender Position Left to Right Preference

### DIFF
--- a/src/main/java/com/bitwig/extensions/controllers/mackie/MackieMcuProExtension.java
+++ b/src/main/java/com/bitwig/extensions/controllers/mackie/MackieMcuProExtension.java
@@ -213,13 +213,18 @@ public class MackieMcuProExtension extends ControllerExtension {
    }
 
    public void initChannelSections() {
-      mainSection = new MixControl(this, midiIn, midiOut, nrOfExtenders, SectionType.MAIN, false);
+      Preferences preferences = host.getPreferences();
+      SettableBooleanValue devicePositionChangeValue = preferences.getBooleanSetting("Left to Right", "Device Poistion(Restart required)", false);
+
+      int sectionIndex = (devicePositionChangeValue.get()) ? 0 : nrOfExtenders;
+      mainSection = new MixControl(this, midiIn, midiOut, sectionIndex, SectionType.MAIN, false);
       sections.add(mainSection);
       for (int i = 0; i < nrOfExtenders; i++) {
          final MidiOut extMidiOut = host.getMidiOutPort(i + 1);
          final MidiIn extMidiIn = host.getMidiInPort(i + 1);
          if (extMidiIn != null && extMidiOut != null) {
-            final MixControl extenderSection = new ExtenderMixControl(this, extMidiIn, extMidiOut, i, false);
+            int extSectionIndex = (devicePositionChangeValue.get()) ? i + 1 : i;
+            final MixControl extenderSection = new ExtenderMixControl(this, extMidiIn, extMidiOut, extSectionIndex, false);
             sections.add(extenderSection);
          }
       }


### PR DESCRIPTION
'The main unit will always be the most right unit and extenders will be added to the left.'

But Solid State Logic's SSL 360 is left to right.
If connected two or more UF8 and UF1, Will see channels 9-16 next 1-8. Very terrible.

This isn't Bitwig's fault, but I added it to resolve the issue like mine.

I have only tested up to 2x UF8. Not tested the 3, 4 units