### PR TITLE
Add customization options to MiniLab 3

### DIFF
--- a/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/MiniLab3Extension.java
+++ b/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/MiniLab3Extension.java
@@ -581,6 +581,18 @@ public class MiniLab3Extension extends ControllerExtension {
                 parameter.value().displayedValue().get()));
     }
     
+    private String formatParameterLabel(final String label, final String source) {
+        if (controlsAnalogLab.get()) {
+            if (label.startsWith("P1 ")) {
+                return label.substring(3);
+            }
+            else {
+                return label;
+            }
+        }
+        return String.format("%s : %s", label, source);
+    }
+
     private void bindKnobValue(final int index, final Layer layer, final Parameter parameter,
         final AbsoluteHardwareControl slider, final StringValue nameSource, final StringValue label,
         final String type) {
@@ -592,12 +604,12 @@ public class MiniLab3Extension extends ControllerExtension {
         layer.bind(slider, v -> oled.enableValues(DisplayMode.PARAM));
         value.displayedValue().markInterested();
         label.addValueObserver(
-            v -> oled.sendSliderInfo(DisplayMode.PARAM, value.get(), String.format("%s : %s", v, nameSource.get()),
+            v -> oled.sendSliderInfo(DisplayMode.PARAM, value.get(), formatParameterLabel(v, nameSource.get()),
                 value.displayedValue().get()));
         value.displayedValue().addValueObserver(displayedValue -> oled.sendEncoderInfo(DisplayMode.PARAM, value.get(),
-            String.format("%s : %s", label.get(), nameSource.get()), displayedValue));
+            formatParameterLabel(label.get(), nameSource.get()), displayedValue));
         value.addValueObserver(
-            v -> oled.sendEncoderInfo(DisplayMode.PARAM, v, String.format("%s : %s", label.get(), nameSource.get()),
+            v -> oled.sendEncoderInfo(DisplayMode.PARAM, v, formatParameterLabel(label.get(), nameSource.get()),
                 value.displayedValue().get()));
         if (type.equals("Fader")) {
             slider.value().addValueObserver(v -> {

--- a/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/PadBank.java
+++ b/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/PadBank.java
@@ -1,18 +1,20 @@
 package com.bitwig.extensions.controllers.arturia.minilab3;
 
 public enum PadBank {
-    BANK_A(0, 0x30, 0x34),
-    BANK_B(1, 0x40, 0x44),
-    TRANSPORT(-1, 0x50, 0x54);
+    BANK_A(0, 0x30, 0x34, "Bank A"),
+    BANK_B(1, 0x40, 0x44, "Bank B"),
+    TRANSPORT(-1, 0x50, 0x54, "Transport");
 
     private final int commandId;
     private final int firstPadId;
     private final int index;
+    private final String displayString;
 
-    PadBank(final int index, final int commandId, final int firstPadId) {
+    PadBank(final int index, final int commandId, final int firstPadId, final String displayString) {
         this.index = index;
         this.commandId = commandId;
         this.firstPadId = firstPadId;
+        this.displayString = displayString;
     }
 
     public int getCommandId() {
@@ -25,5 +27,10 @@ public enum PadBank {
 
     public int getFirstPadId() {
         return firstPadId;
+    }
+
+    public String displayName()
+    {
+        return displayString;
     }
 }

--- a/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/PadBankLayerSelector.java
+++ b/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/PadBankLayerSelector.java
@@ -1,0 +1,49 @@
+package com.bitwig.extensions.controllers.arturia.minilab3;
+
+import java.util.EnumSet;
+
+import com.bitwig.extensions.framework.Layer;
+
+public class PadBankLayerSelector
+{
+    private final MiniLab3Extension driver;
+    private EnumSet<PadBank> padBankSelection;
+
+    private final Layer layer;
+
+    public PadBankLayerSelector(final MiniLab3Extension driver, final Layer layer, EnumSet<PadBank> availablePadBanks)
+    {
+        this.driver = driver;
+        this.layer = layer;
+        var host = driver.getHost();
+        padBankSelection = EnumSet.noneOf(PadBank.class);
+        for (PadBank value : availablePadBanks)
+        {
+            var setting = host.getPreferences().getBooleanSetting(value.displayName(), layer.getName(), false);
+            setting.addValueObserver(active -> handleSettingChanged(value, active));
+        }
+    }
+
+    public PadBankLayerSelector(final MiniLab3Extension driver, final Layer layer)
+    {
+        this(driver, layer, EnumSet.allOf(PadBank.class));
+    }
+
+    private void handleSettingChanged(PadBank padBank, boolean active)
+    {
+        if (active)
+            padBankSelection.add(padBank);
+        else
+            padBankSelection.remove(padBank);
+        update();
+    }
+
+    public void update()
+    {
+        PadBank currentPadBank = driver.getPadBankWithTransport().get();
+        boolean isActive = padBankSelection.contains(currentPadBank);
+        if (layer.isActive() != isActive)
+            MiniLab3Extension.println("%s layer : %s", layer.getName(), isActive ? "ON" : "OFF");
+        layer.setIsActive(isActive);
+    }
+}

--- a/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/RgbButton.java
+++ b/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/RgbButton.java
@@ -4,6 +4,7 @@ import com.bitwig.extension.controller.api.*;
 import com.bitwig.extensions.framework.Layer;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class RgbButton {
@@ -82,6 +83,19 @@ public class RgbButton {
       layer.bind(hwButton, hwButton.pressedAction(), () -> target.accept(true));
       layer.bind(hwButton, hwButton.releasedAction(), () -> target.accept(false));
       layer.bindLightState(lightSource::get, light);
+   }
+
+   public void bind(
+      final Layer layer,
+      final Runnable target,
+      final Function<Boolean, RgbLightState> lightSource,
+      boolean onRelease)
+   {
+      if (onRelease)
+         layer.bind(hwButton, hwButton.releasedAction(), () -> target.run());
+      else
+         layer.bind(hwButton, hwButton.pressedAction(), () -> target.run());
+      layer.bindLightState(() -> lightSource.apply(hwButton.isPressed().get()), light);
    }
 
    public void bind(final Layer layer, final Runnable action, final Supplier<RgbLightState> lightSource) {

--- a/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/RgbLightState.java
+++ b/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/RgbLightState.java
@@ -15,12 +15,15 @@ public class RgbLightState extends InternalHardwareLightState {
     public static final RgbLightState WHITE = new RgbLightState(127, 127, 127);
     public static final RgbLightState OFF = new RgbLightState(0, 0, 0);
     public static final RgbLightState YELLOW = new RgbLightState(127, 127, 0);
+    public static final RgbLightState YELLOW_DIMMED = new RgbLightState(0x14, 0x14, 0);
     public static final RgbLightState ORANGE = new RgbLightState(127, 0x32, 0);
     public static final RgbLightState ORANGE_DIMMED = new RgbLightState(0x14, 0x05, 0);
     public static final RgbLightState GREEN = new RgbLightState(0, 127, 0);
     public static final RgbLightState GREEN_DIMMED = new RgbLightState(0, 0x14, 0);
     public static final RgbLightState RED_DIMMED = new RgbLightState(0x14, 0, 0);
     public static final RgbLightState WHITE_DIMMED = new RgbLightState(0x14, 0x14, 0x14);
+    public static final RgbLightState MAGENTA = new RgbLightState(0xc0, 0x20, 0xa0);
+    public static final RgbLightState MAGENTA_DIMMED = new RgbLightState(0x18, 0x04, 0x12);
 
     private final byte red;
     private final byte green;

--- a/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/TransportButtonAction.java
+++ b/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/TransportButtonAction.java
@@ -1,0 +1,80 @@
+package com.bitwig.extensions.controllers.arturia.minilab3;
+
+import com.bitwig.extension.controller.ControllerExtension;
+import com.bitwig.extension.controller.api.Application;
+import com.bitwig.extension.controller.api.SettableEnumValue;
+import com.bitwig.extension.controller.api.Transport;
+
+public class TransportButtonAction
+{
+    private SettableEnumValue behaviorSetting;
+    private TransportButtonBehavior behavior;
+
+    private OledDisplay oled;
+
+    private Transport transport;
+
+    private Application application;
+
+    public TransportButtonAction(
+        final ControllerExtension controller,
+        final String buttonName,
+        OledDisplay oled,
+        Transport transport,
+        Application application)
+    {
+        var host = controller.getHost();
+        this.oled = oled;
+        this.transport = transport;
+        this.application = application;
+        behaviorSetting = host.getPreferences().getEnumSetting(String.format("%s button behavior", buttonName),
+            "Transport Pads",
+            new String[] { TransportButtonBehavior.LOOP.displayName(), TransportButtonBehavior.TAP.displayName(),
+                    TransportButtonBehavior.METRONOME.displayName(), TransportButtonBehavior.UNDO.displayName() },
+            buttonName);
+        behaviorSetting.addValueObserver(this::handleBehaviorChanged);
+    }
+
+    public void pressedAction()
+    {
+        switch (behavior)
+        {
+        case LOOP -> {
+            transport.isArrangerLoopEnabled().toggle();
+            final boolean loopEnabled = transport.isArrangerLoopEnabled().get();
+            oled.sendText(DisplayMode.LOOP_VALUE, "Loop Mode", loopEnabled ? "ON" : "OFF");
+        }
+        case TAP -> {
+            transport.tapTempo();
+            final int tempo = (int)Math.round(transport.tempo().value().getRaw());
+            oled.sendText(DisplayMode.TEMPO, "Tap Tempo", String.format("%d BPM", tempo));
+        }
+        case METRONOME -> {
+            oled.sendText(DisplayMode.STATE_INFO, "Metronome",
+                transport.isMetronomeEnabled().get() ? "Off" : "On");
+            transport.isMetronomeEnabled().toggle();
+        }
+        case UNDO -> {
+            oled.sendText(DisplayMode.STATE_INFO, "Undo", application.canUndo().get() ? "OK" : "Impossible");
+            application.undo();
+        }
+        }
+    }
+
+    public RgbLightState getLightState(boolean pressed)
+    {
+        return switch (behavior)
+        {
+        case LOOP -> transport.isArrangerLoopEnabled().get() ? RgbLightState.ORANGE
+            : RgbLightState.ORANGE_DIMMED;
+        case TAP -> pressed ? RgbLightState.WHITE : RgbLightState.WHITE_DIMMED;
+        case METRONOME -> transport.isMetronomeEnabled().get() ? RgbLightState.MAGENTA
+            : RgbLightState.MAGENTA_DIMMED;
+        case UNDO -> application.canUndo().get() ? RgbLightState.YELLOW_DIMMED : RgbLightState.OFF;
+        };
+    }
+
+    private void handleBehaviorChanged(String behaviorName){
+        behavior = TransportButtonBehavior.valueOf(behaviorName.toUpperCase());
+    }
+}

--- a/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/TransportButtonBehavior.java
+++ b/src/main/java/com/bitwig/extensions/controllers/arturia/minilab3/TransportButtonBehavior.java
@@ -1,0 +1,11 @@
+package com.bitwig.extensions.controllers.arturia.minilab3;
+
+public enum TransportButtonBehavior
+{
+    LOOP, TAP, METRONOME, UNDO;
+
+    public String displayName()
+    {
+        return name().substring(0, 1).toUpperCase() + name().substring(1).toLowerCase();
+    }
+}


### PR DESCRIPTION
# Extra Features for Arturia MiniLab 3

### Transport options

- **Undo**
- **Metronome**

### Fader options

- Swap track volume and pan to match Arturia mode
- **Headphones** track on fader 4 (can also be used for master track)
- MIDI faders:
    1. Channel **aftertouch**
    2. **Mod Wheel** (CC 1)
    3. **Expresion** (CC 11)

### Encoders

- MIDI encoders: **same CC's as in Arturia mode**

### Main Encoder

- Preset navigation:
    - Rotate:
        - If Analog Lab detected: **change Analog Lab instrument**, without requiring confirmation by pressing the knob
        - Otherwise: **change Komplete Kontrol instrument** (CC's 114 et 115)
    - Press + rotate:
        - Shift drum pad notes
