### PR TITLE
SSL UF8 - Fix VU Meter - Avoid checking the Last Value in updateVuValue

### DIFF
--- a/src/main/java/com/bitwig/extensions/controllers/mcu/bindings/VuMeterBinding.java
+++ b/src/main/java/com/bitwig/extensions/controllers/mcu/bindings/VuMeterBinding.java
@@ -22,7 +22,7 @@ public class VuMeterBinding extends Binding<Track, DisplayManager> {
     }
     
     private void updateVuValue(final int value) {
-        if (isActive() && value != lastValue) {
+        if (isActive()) {
             getTarget().sendVuUpdate(index, value);
         }
         lastValue = value;


### PR DESCRIPTION
If Vu Value is not received for a certain period of time, UF8's level meter will turns off.
The level meter may not display correctly in certain situations, such as Pads sound.


https://github.com/bitwig/bitwig-extensions/assets/52376580/b70d1cd0-041e-4fb3-bd80-801b4c4d4a52

