### PR TITLE
Fixed encoding text that gets send to NI and Mackie controllers for d…

### DIFF
--- a/src/main/java/com/bitwig/extensions/controllers/mackie/display/LcdDisplay.java
+++ b/src/main/java/com/bitwig/extensions/controllers/mackie/display/LcdDisplay.java
@@ -7,6 +7,7 @@ import com.bitwig.extensions.controllers.mackie.Midi;
 import com.bitwig.extensions.controllers.mackie.StringUtil;
 import com.bitwig.extensions.controllers.mackie.section.SectionType;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -233,9 +234,9 @@ public class LcdDisplay implements DisplaySource {
 
    private void sendFullRow(final int row, final String text) {
       rowDisplayBuffer[6] = (byte) (row * LcdDisplay.ROW2_START);
-      final char[] ca = text.toCharArray();
+      final byte[] ca = text.getBytes(StandardCharsets.US_ASCII);
       for (int i = 0; i < displayLen; i++) {
-         rowDisplayBuffer[i + 7] = i < ca.length ? (byte) ca[i] : 32;
+         rowDisplayBuffer[i + 7] = i < ca.length ? ca[i] : 32;
       }
       displayRep.line(row).text().setValue(text);
       midiOut.sendSysex(rowDisplayBuffer);
@@ -263,9 +264,9 @@ public class LcdDisplay implements DisplaySource {
 
    private void sendTextSegFull(final DisplaySource source, final int row, final int segment, final String text) {
       segBuffer[6] = (byte) (row * LcdDisplay.ROW2_START + segment * segmentLength + segmentOffset);
-      final char[] ca = text.toCharArray();
+      final byte[] ca = text.getBytes(StandardCharsets.US_ASCII);
       for (int i = 0; i < segmentLength; i++) {
-         segBuffer[i + 7] = i < ca.length ? (byte) ca[i] : 32;
+         segBuffer[i + 7] = i < ca.length ? ca[i] : 32;
          lines[row][segment * 7 + i] = (char) segBuffer[i + 7];
       }
       midiOut.sendSysex(segBuffer);
@@ -273,7 +274,7 @@ public class LcdDisplay implements DisplaySource {
    }
 
    private void sendTextSeg(final DisplaySource source, final int row, final int segment, final String text) {
-      final char[] ca = text.toCharArray();
+      final byte[] ca = text.getBytes(StandardCharsets.US_ASCII);
       if (segment == 8) {
          if (isLowerDisplay()) {
             handleLastCell(row, segment, ca);
@@ -292,10 +293,10 @@ public class LcdDisplay implements DisplaySource {
       }
    }
 
-   private void handleLastCell(final int row, final int segment, final char[] ca) {
+   private void handleLastCell(final int row, final int segment, final byte[] ca) {
       segBufferExp[6] = (byte) (row * LcdDisplay.ROW2_START + segment * segmentLength + segmentOffset);
       for (int i = 0; i < segmentLength; i++) {
-         segBufferExp[i + 7] = i < ca.length ? (byte) ca[i] : 32;
+         segBufferExp[i + 7] = i < ca.length ? ca[i] : 32;
       }
       if (segment < segmentLength + 1) {
          segBufferExp[6 + segmentLength] = ' ';

--- a/src/main/java/com/bitwig/extensions/controllers/nativeinstruments/komplete/midi/NhiaSysexTextCommand.java
+++ b/src/main/java/com/bitwig/extensions/controllers/nativeinstruments/komplete/midi/NhiaSysexTextCommand.java
@@ -1,5 +1,8 @@
 package com.bitwig.extensions.controllers.nativeinstruments.komplete.midi;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import com.bitwig.extension.controller.api.MidiOut;
 
 /**
@@ -34,8 +37,9 @@ public class NhiaSysexTextCommand extends NhiaSysexCommand {
       dataArray[12] = (byte) track;
       final byte[] sendarray = new byte[dataArray.length + text.length()];
       System.arraycopy(dataArray, 0, sendarray, 0, 13);
-      for (int i = 0; i < text.length(); i++) {
-         sendarray[13 + i] = (byte) text.charAt(i);
+      final byte[] chars = text.getBytes(StandardCharsets.US_ASCII);
+      for (int i = 0; i < chars.length; i++) {
+         sendarray[13 + i] = chars[i];
       }
       sendarray[sendarray.length - 1] = SYSEX_END;
       midiOut.sendSysex(sendarray);

--- a/src/main/java/com/bitwig/extensions/controllers/nativeinstruments/maschine/MaschineExtension.java
+++ b/src/main/java/com/bitwig/extensions/controllers/nativeinstruments/maschine/MaschineExtension.java
@@ -14,6 +14,7 @@ import com.bitwig.extensions.framework.Layers;
 import com.bitwig.extensions.framework.time.TimedEvent;
 import com.bitwig.extensions.framework.values.BooleanValueObject;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -961,9 +962,9 @@ public class MaschineExtension extends ControllerExtension implements JogWheelDe
       }
       lastSenGrids[grid] = text;
       displayBuffer[6] = (byte) (Math.min(grid, 3) * 28);
-      final char[] ca = text.toCharArray();
+      final byte[] ca = text.getBytes(StandardCharsets.US_ASCII);
       for (int i = 0; i < 28; i++) {
-         displayBuffer[i + 7] = i < ca.length ? (byte) ca[i] : 32;
+         displayBuffer[i + 7] = i < ca.length ? ca[i] : 32;
       }
       midiOut.sendSysex(displayBuffer);
    }


### PR DESCRIPTION
The Maschine extension was throwing exceptions when displaying names that include unusual characters, such as "Stereoizer²". These cases were showing up in our test suite when loading presets with all controllers connected, after v19 got updated to only accept valid SysEx.

I fixed it the same way as done in the SysexBuilder helper class, by calling text.getBytes(StandardCharsets.US_ASCII) instead of text.toCharArray().